### PR TITLE
Follow redirects in curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage / Installation
 You can also use the following command to get and install the latest version
 directly from the GitHub repository:
 
-    curl https://raw.github.com/MatmaRex/mediawikireleasenotes-driver/master/mediawikireleasenotes-driver-installer.sh | sh
+    curl -L https://raw.github.com/MatmaRex/mediawikireleasenotes-driver/master/mediawikireleasenotes-driver-installer.sh | sh
 
 From this point on, all merges of RELEASE-NOTES files will use the new algorithm.
 


### PR DESCRIPTION
GitHub seems to change domains every so often for where it hosts raw content.
Added the -L flag to curl so it follows the redirect.
